### PR TITLE
react eslintrc extends non-existent file

### DIFF
--- a/apps/react-client/.eslintrc.json
+++ b/apps/react-client/.eslintrc.json
@@ -1,4 +1,4 @@
 {
-  "extends": ["plugin:@nrwl/nx/react", "../.eslintrc.json"],
+  "extends": ["plugin:@nrwl/nx/react", "../../.eslintrc.json"],
   "ignorePatterns": ["!**/*"]
 }


### PR DESCRIPTION
The eslintrc for the react app extends a non-existent eslint file in the parent directory as opposed to the grandparent directory. Both angular and cli app extend from grandparent directory.